### PR TITLE
Fixed HF download + gui stable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,6 @@ for older docker without GUI use `casalioy:latest` might deprecate soon
 
 > Fetch the default models
 
-```
-cd models
-wget https://huggingface.co/Pi3141/alpaca-native-7B-ggml/resolve/397e872bf4c83f4c642317a5bf65ce84a105786e/ggml-model-q4_0.bin &&
-wget https://huggingface.co/eachadea/ggml-vicuna-7b-1.1/resolve/main/ggml-vic7b-q5_1.bin
-cd ../
-```
-
 > All set! Proceed with ingesting your [dataset](#ingesting-your-own-dataset)
 
 ### Build it from source
@@ -74,20 +67,12 @@ pip uninstall -y llama-cpp-python
 CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install --force llama-cpp-python
 ```
 
-> Download the 2 models and place them in a folder called `./models`:
-
-- LLM: default
-  is [ggml-vic7b-q5_1](https://huggingface.co/eachadea/ggml-vicuna-7b-1.1/resolve/main/ggml-vic7b-q5_1.bin)
-- Embedding: default
-  to [ggml-model-q4_0](https://huggingface.co/Pi3141/alpaca-native-7B-ggml/resolve/397e872bf4c83f4c642317a5bf65ce84a105786e/ggml-model-q4_0.bin).
-
 > > Edit the example.env to fit your models and rename it to .env
 
 ```env
 # Generic
-# Generic
 MODEL_N_CTX=1024
-TEXT_EMBEDDINGS_MODEL=all-MiniLM-L6-v2
+TEXT_EMBEDDINGS_MODEL=sentence-transformers/all-MiniLM-L6-v2
 TEXT_EMBEDDINGS_MODEL_TYPE=HF  # LlamaCpp or HF
 USE_MLOCK=true
 
@@ -99,10 +84,12 @@ INGEST_CHUNK_OVERLAP=50
 
 # Generation
 MODEL_TYPE=LlamaCpp # GPT4All or LlamaCpp
-MODEL_PATH=models/ggml-vic7b-q5_1.bin
+MODEL_PATH=eachadea/ggml-vicuna-7b-1.1/ggml-vic7b-q5_1.bin
 MODEL_TEMP=0.8
 MODEL_STOP=[STOP]
 CHAIN_TYPE=stuff
+N_RETRIEVE_DOCUMENTS=100 # How many documents to retrieve from the db
+N_FORWARD_DOCUMENTS=6 # How many documents to forward to the LLM, chosen among those retrieved
 ```
 
 This should look like this
@@ -111,14 +98,13 @@ This should look like this
 └── repo
       ├── startLLM.py
       ├── casalioy
-      │   └── ingest.py, load_env.py, startLLM.py, gui.py, __init__.py
+      │   └── ingest.py, load_env.py, startLLM.py, gui.py, ...
       ├── source_documents
       │   └── sample.csv
-      │   └── shor.pdfstate_of_the_union.txt
-      │   └── state_of_the_union.txt
+      │   └── ...
       ├── models
       │   ├── ggml-vic7b-q5_1.bin
-      │   └── ggml-model-q4_0.bin
+      │   └── ...
       └── .env, convert.py, Dockerfile
 ```
 
@@ -126,7 +112,7 @@ This should look like this
 
 To automatically ingest different data types (.txt, .pdf, .csv, .epub, .html, .docx, .pptx, .eml, .msg)
 
-> This repo includes dummy [files](https://github.com/su77ungr/CASALIOY/tree/main/source_documents)
+> This repo includes dummy [files](https://github.com/su77ungr/CASALIOY/main/source_documents/)
 > inside `source_documents` to run tests with.
 
 ```shell
@@ -181,7 +167,6 @@ streamlit run casalioy/gui.py
 
 | Model                                                                                                                                            | BoolQ | PIQA | HellaSwag | WinoGrande | ARC-e | ARC-c | OBQA | Avg. |
 |:-------------------------------------------------------------------------------------------------------------------------------------------------|:-----:|:----:|:---------:|:----------:|:-----:|:-----:|:----:|:----:|
-| [ggml-vic-7b-uncensored](https://huggingface.co/datasets/dnato/ggjt-v1-vic7b-uncensored-q4_0.bin/resolve/main/ggjt-v1-vic7b-uncensored-q4_0.bin) | 73.4  | 74.8 |   63.4    |    64.7    | 54.9  | 36.0  | 40.2 | 58.2 |
 | [GPT4All-13b-snoozy q5](https://huggingface.co/TheBloke/GPT4All-13B-snoozy-GGML/blob/main/GPT4All-13B-snoozy.ggml.q5_1.bin)                      | 83.3  | 79.2 |   75.0    |    71.3    | 60.9  | 44.2  | 43.4 | 65.3 |
 
 ### models inside of the GPT-J ecosphere
@@ -223,6 +208,7 @@ leaving your environment, and with reasonable performance.
   extracted from the local vector store using a similarity search to locate the right piece of context from the docs.
 
 <br><br>
+
 
 # Disclaimer
 

--- a/casalioy/ask_libgen.py
+++ b/casalioy/ask_libgen.py
@@ -20,13 +20,12 @@ from casalioy.load_env import (
     model_temp,
     n_gpu_layers,
     persist_directory,
-    print_HTML,
-    prompt_HTML,
     use_mlock,
 )
 from casalioy.startLLM import QASystem
+from casalioy.utils import print_HTML, prompt_HTML
 
-max_doc_size_mb = 10
+max_doc_size_mb = 5
 out_path = Path("source_documents/libgen")
 
 logging.getLogger().setLevel(logging.WARNING)  # because libgenesis changes it
@@ -38,9 +37,10 @@ os.mkdir(out_path)
 
 def load_documents(keyword: str, n: int = 3) -> None:
     """load random documents from LG using keyword"""
-    lg = Libgen()
+    lg = Libgen(result_limit=100)
     result = asyncio.run(lg.search(keyword))
     dl_N = 0
+    print_HTML(f"<r>Searching for interesting documents (max {n})</r>")
     with ProgressBar() as pb:
         for item_id in pb(result):
             if dl_N >= n:

--- a/casalioy/gui.py
+++ b/casalioy/gui.py
@@ -1,14 +1,13 @@
 """LLM through a GUI"""
 
 import streamlit as st
-from load_env import get_embedding_model, model_n_ctx, model_path, model_stop, model_temp, n_gpu_layers, persist_directory, print_HTML, use_mlock
+from load_env import get_embedding_model, model_n_ctx, model_path, model_stop, model_temp, n_gpu_layers, persist_directory, use_mlock, print_HTML
 from streamlit_chat import message
 from streamlit_extras.add_vertical_space import add_vertical_space
 from streamlit_extras.colored_header import colored_header
 
 from casalioy import startLLM
 from casalioy.startLLM import QASystem
-
 title = "CASALIOY"
 
 

--- a/casalioy/ingest.py
+++ b/casalioy/ingest.py
@@ -20,10 +20,12 @@ from langchain.document_loaders import (
     UnstructuredPowerPointLoader,
 )
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from load_env import chunk_overlap, chunk_size, documents_directory, get_embedding_model, persist_directory, print_HTML, prompt_HTML
+from load_env import chunk_overlap, chunk_size, documents_directory, get_embedding_model, persist_directory
 from prompt_toolkit import PromptSession
 from prompt_toolkit.shortcuts import ProgressBar
 from qdrant_client import QdrantClient, models
+
+from casalioy.utils import print_HTML, prompt_HTML
 
 
 class Ingester:

--- a/casalioy/startLLM.py
+++ b/casalioy/startLLM.py
@@ -18,12 +18,13 @@ from casalioy.load_env import (
     model_stop,
     model_temp,
     model_type,
+    n_forward_documents,
     n_gpu_layers,
+    n_retrieve_documents,
     persist_directory,
-    print_HTML,
-    prompt_HTML,
     use_mlock,
 )
+from casalioy.utils import print_HTML, prompt_HTML
 
 
 class QASystem:
@@ -86,6 +87,7 @@ class QASystem:
             return_source_documents=True,
             chain_type_kwargs=get_prompt_template_kwargs(),
         )
+        self.qa.retriever.search_kwargs = {**self.qa.retriever.search_kwargs, "k": n_forward_documents, "fetch_k": n_retrieve_documents}
 
     def prompt_once(self, query: str) -> tuple[str, str]:
         """run a prompt"""

--- a/meta.json
+++ b/meta.json
@@ -1,1 +1,0 @@
-{"collections": {"db": {"vectors": {"size": 4096, "distance": "Cosine", "hnsw_config": null, "quantization_config": null}, "shard_number": null, "replication_factor": null, "write_consistency_factor": null, "on_disk_payload": null, "hnsw_config": null, "wal_config": null, "optimizers_config": null, "init_from": null, "quantization_config": null}}, "aliases": {}}


### PR DESCRIPTION
fixes #61 

Major:
 * if the model isn't a local file, attempt downloading it from HF (cached)
 * Add two parameters to control how many documents are passed to the LLM
 * added missing import of print_html, initiated inside load_env


Minor:

    fix a formatting bug
    readme